### PR TITLE
fix: add missing ESM patch for ajv/dist/runtime/equal in serialize

### DIFF
--- a/core/src/compile/serialize.js
+++ b/core/src/compile/serialize.js
@@ -62,6 +62,10 @@ export async function serialize (compiledLayout) {
     code = 'import ucs2length from "ajv/dist/runtime/ucs2length.js";\n' + code
     code = code.replace(/require\("ajv\/dist\/runtime\/ucs2length"\)/g, 'ucs2length')
   }
+  if (code.includes('require("ajv/dist/runtime/equal")')) {
+    code = 'import equal from "ajv/dist/runtime/equal.js";\n' + code
+    code = code.replace(/require\("ajv\/dist\/runtime\/equal"\)\.default/g, 'equal')
+  }
 
   // import only the current locale from ajv-i18n
   let ajvI18nPath = `ajv-i18n/localize/${compiledLayout.locale}/index.js`


### PR DESCRIPTION
## Problem

When a JSON schema uses a non-primitive `const` value (e.g. `const: []`), AJV's standalone code generator emits a `require("ajv/dist/runtime/equal")` call to perform deep equality checks. This breaks ESM builds.

Two similar cases were already handled in `serialize.js`:
- `require("ajv-formats/dist/formats")` → patched to ESM import
- `require("ajv/dist/runtime/ucs2length")` → patched to ESM import

But `require("ajv/dist/runtime/equal")` was missing.

## Root cause

The `equal` runtime helper is used by AJV when comparing non-primitive `const` values (arrays, objects). In this case it was triggered by a schema with `roles: { type: 'array', const: [] }` in `@data-fair/lib-common-types/access-ref`.

## Fix

Add the same ESM patching pattern for `ajv/dist/runtime/equal`, consistent with the existing patches.

```js
if (code.includes('require("ajv/dist/runtime/equal")')) {
  code = 'import equal from "ajv/dist/runtime/equal.js";\n' + code
  code = code.replace(/require\("ajv\/dist\/runtime\/equal"\)\.default/g, 'equal')
}
```

This mirrors the fix already present in [`@data-fair/lib-types-builder`](https://github.com/data-fair/lib/blob/bd497c3e81f355d2c92e151085bc92072effcea9/packages/types-builder/build.ts#L222).