### PR TITLE
perf: fast-path validation of discriminated oneOfs of $refs via if/then

### DIFF
--- a/core/src/compile/index.js
+++ b/core/src/compile/index.js
@@ -97,20 +97,27 @@ export function compile (_schema, partialOptions = {}) {
   // matching branch (huge speedup on large discriminated unions) while keeping the
   // exact same validation semantics. Done after the skeleton is built (it still
   // sees the original `oneOf`) and before compiling the validators.
+  options.ajv.removeSchema(schema.$id) // just in case it was previously added
+  const uriResolver = options.ajv.opts.uriResolver
   /** @type {Record<string, any>} */
   const schemasById = { [schema.$id]: schema }
   for (const [key, value] of Object.entries(options.ajv.schemas)) {
-    if (key.startsWith('https://json-schema.org/') || !value?.schema) continue
+    if (key.startsWith('https://json-schema.org/') || !value?.schema || typeof value.schema !== 'object') continue
     schemasById[key] = value.schema
   }
-  for (const registeredSchema of new Set(Object.values(schemasById))) {
-    rewriteDiscriminatedOneOfs(registeredSchema, schemasById)
+  rewriteDiscriminatedOneOfs(schema, schemasById, schema.$id, uriResolver)
+  for (const [key, registeredSchema] of Object.entries(schemasById)) {
+    if (registeredSchema === schema) continue
+    // registered schemas belong to the caller, do not mutate them, only replace
+    // them in the ajv registry with a rewritten clone
+    const rewrittenSchema = clone(registeredSchema)
+    if (rewriteDiscriminatedOneOfs(rewrittenSchema, schemasById, key, uriResolver)) {
+      options.ajv.removeSchema(key)
+      options.ajv.addSchema(rewrittenSchema, key === rewrittenSchema.$id ? undefined : key)
+    }
   }
 
-  options.ajv.removeSchema(schema.$id) // just in case it was previously added
   options.ajv.addSchema(schema)
-
-  const uriResolver = options.ajv.opts.uriResolver
   /** @type {Record<string, import('ajv').ValidateFunction>} */
   const validates = {}
 

--- a/core/src/compile/index.js
+++ b/core/src/compile/index.js
@@ -7,6 +7,7 @@ import { resolveLocaleRefs } from './utils/resolve-refs.js'
 import { resolveXI18n } from './utils/x-i18n.js'
 import { clone } from '@json-layout/vocabulary'
 import { fillOptions } from './options.js'
+import { rewriteDiscriminatedOneOfs } from './utils/discriminated-oneof.js'
 
 export { resolveLocaleRefs } from './utils/resolve-refs.js'
 export { resolveXI18n } from './utils/x-i18n.js'
@@ -90,6 +91,20 @@ export function compile (_schema, partialOptions = {}) {
       }
     }
     if (!updatedPropertyKeys) break
+  }
+
+  // Turn discriminated `oneOf`s into `if/then` chains so ajv validates only the
+  // matching branch (huge speedup on large discriminated unions) while keeping the
+  // exact same validation semantics. Done after the skeleton is built (it still
+  // sees the original `oneOf`) and before compiling the validators.
+  /** @type {Record<string, any>} */
+  const schemasById = { [schema.$id]: schema }
+  for (const [key, value] of Object.entries(options.ajv.schemas)) {
+    if (key.startsWith('https://json-schema.org/') || !value?.schema) continue
+    schemasById[key] = value.schema
+  }
+  for (const registeredSchema of new Set(Object.values(schemasById))) {
+    rewriteDiscriminatedOneOfs(registeredSchema, schemasById)
   }
 
   options.ajv.removeSchema(schema.$id) // just in case it was previously added

--- a/core/src/compile/utils/discriminated-oneof.js
+++ b/core/src/compile/utils/discriminated-oneof.js
@@ -17,27 +17,38 @@
 // contribute annotations, so `unevaluatedProperties` keeps working.
 //
 // Only applied when every branch is a `$ref` exposing a resolvable const for the
-// discriminator property; otherwise the `oneOf` is left untouched, so schemas that
-// don't fit the fast path keep their exact previous behaviour. Deep branch schemas
-// are reused as-is (same object, same `__pointer`), so compiled error paths stay
-// stable.
+// discriminator property, requiring that property, and with no const shared by 2
+// branches; otherwise the `oneOf` is left untouched, so schemas that don't fit the
+// fast path keep their exact previous behaviour. Deep branch schemas are reused
+// as-is (same object, same `__pointer`), so compiled error paths stay stable.
+
+// values stored under these keywords are data, not schemas, do not recurse into them
+const dataKeywords = ['const', 'enum', 'default', 'examples']
+// values stored under these keywords are maps whose values are schemas
+const schemaMapKeywords = ['properties', 'patternProperties', 'dependentSchemas', '$defs', 'definitions']
 
 /**
  * @param {any} schema the fragment a `$ref` points to
  * @param {string} discriminator
  * @returns {unknown}
  */
-const branchConst = (schema, discriminator) => schema?.properties?.[discriminator]?.const
+const branchConst = (schema, discriminator) => {
+  // the discriminator property must be required, otherwise data without it could
+  // match a full branch while it matches none of the tag-only guards
+  if (!Array.isArray(schema?.required) || !schema.required.includes(discriminator)) return undefined
+  return schema.properties?.[discriminator]?.const
+}
 
 /**
  * @param {Record<string, any>} schemasById all schemas known to the ajv instance, keyed by $id
- * @param {any} rootSchema the schema currently being walked (for local `#/...` refs)
+ * @param {string} baseId the id the schema currently being walked is registered as (for relative refs)
+ * @param {any} uriResolver the uri resolver of the ajv instance
  * @param {string} ref
  * @returns {any}
  */
-const resolveRef = (schemasById, rootSchema, ref) => {
-  const [id, fragment] = ref.split('#')
-  let node = id ? schemasById[id] : rootSchema
+const resolveRef = (schemasById, baseId, uriResolver, ref) => {
+  const [id, fragment] = (ref.startsWith('#') ? baseId + ref : uriResolver.resolve(baseId, ref)).split('#')
+  let node = schemasById[id]
   for (const part of (fragment ?? '').split('/').filter(Boolean)) {
     node = node?.[part.replace(/~1/g, '/').replace(/~0/g, '~')]
   }
@@ -49,29 +60,44 @@ const resolveRef = (schemasById, rootSchema, ref) => {
  * equivalent, faster `allOf` of `if/then` guards. Mutates in place.
  * @param {any} rootSchema
  * @param {Record<string, any>} schemasById
+ * @param {string} baseId
+ * @param {any} uriResolver
+ * @returns {boolean} true if at least one `oneOf` was rewritten
  */
-export const rewriteDiscriminatedOneOfs = (rootSchema, schemasById) => {
+export const rewriteDiscriminatedOneOfs = (rootSchema, schemasById, baseId, uriResolver) => {
   const seen = new Set()
-  /** @param {any} node */
-  const walk = (node) => {
+  let changed = false
+  /**
+   * @param {any} node
+   * @param {boolean} isSchema false when node is a map of schemas (e.g. the value of `properties`)
+   */
+  const walk = (node, isSchema) => {
     if (!node || typeof node !== 'object' || seen.has(node)) return
     seen.add(node)
     if (Array.isArray(node)) {
-      for (const item of node) walk(item)
+      for (const item of node) walk(item, true)
+      return
+    }
+    if (!isSchema) {
+      for (const value of Object.values(node)) walk(value, true)
       return
     }
     const discriminator = node.discriminator?.propertyName
     if (typeof discriminator === 'string' && Array.isArray(node.oneOf)) {
       const tagOnlyBranches = []
       const guards = []
+      const constValues = new Set()
       let fastPath = true
       for (const branch of node.oneOf) {
         // Only branches that are a plain `$ref` are eligible: an inline branch is
         // addressable by its own `#/.../oneOf/N` pointer (json-layout compiles a
         // validator for it), which we must not disturb. `$ref` branches are
         // addressed through their ref target, so the reshaped `oneOf` below is safe.
-        const constValue = branch?.$ref ? branchConst(resolveRef(schemasById, rootSchema, branch.$ref), discriminator) : undefined
-        if (constValue === undefined) { fastPath = false; break } // keep the oneOf untouched
+        const constValue = branch?.$ref ? branchConst(resolveRef(schemasById, baseId, uriResolver, branch.$ref), discriminator) : undefined
+        // keep the oneOf untouched when a branch does not fit the fast path or when
+        // 2 branches share the same const (the tag cannot select "exactly one" branch)
+        if (constValue === undefined || constValues.has(constValue)) { fastPath = false; break }
+        constValues.add(constValue)
         const guard = { required: [discriminator], properties: { [discriminator]: { const: constValue } } }
         tagOnlyBranches.push(guard)
         guards.push({ if: guard, then: branch })
@@ -82,12 +108,14 @@ export const rewriteDiscriminatedOneOfs = (rootSchema, schemasById) => {
         // ajv's `discriminator` keyword is incompatible with `unevaluatedProperties`;
         // the tag-only `oneOf` is cheap enough to resolve sequentially.
         delete node.discriminator
+        changed = true
       }
     }
     for (const key of Object.keys(node)) {
-      if (key === 'discriminator') continue
-      walk(node[key])
+      if (key === 'discriminator' || dataKeywords.includes(key)) continue
+      walk(node[key], !schemaMapKeywords.includes(key))
     }
   }
-  walk(rootSchema)
+  walk(rootSchema, true)
+  return changed
 }

--- a/core/src/compile/utils/discriminated-oneof.js
+++ b/core/src/compile/utils/discriminated-oneof.js
@@ -1,0 +1,93 @@
+// Speed up validation of a discriminated `oneOf` of `$ref`s.
+//
+// A plain `oneOf` validates the data against *every* branch in full (even more so
+// with `allErrors`), which on a large discriminated union (e.g. one branch per
+// element type, nested in a big document) costs seconds on each revalidation.
+//
+// The rewrite keeps a cheap, tag-only `oneOf` — one `{ required, properties: { tag:
+// { const } } }` per branch — so the "exactly one variant" semantics and the error
+// json-layout surfaces on the `$oneOf` node (e.g. "choose a variant") are preserved
+// unchanged. The actual deep validation of the selected branch is moved to an
+// `allOf` of `if/then` guards keyed on the same tag, so only the matching branch is
+// validated in full.
+//
+// We deliberately do NOT use ajv's native `discriminator` keyword: it does not
+// participate in `unevaluatedProperties` evaluation and would wrongly flag every
+// property of the matched branch as unevaluated. `oneOf`/`allOf`/`if`/`then` all
+// contribute annotations, so `unevaluatedProperties` keeps working.
+//
+// Only applied when every branch is a `$ref` exposing a resolvable const for the
+// discriminator property; otherwise the `oneOf` is left untouched, so schemas that
+// don't fit the fast path keep their exact previous behaviour. Deep branch schemas
+// are reused as-is (same object, same `__pointer`), so compiled error paths stay
+// stable.
+
+/**
+ * @param {any} schema the fragment a `$ref` points to
+ * @param {string} discriminator
+ * @returns {unknown}
+ */
+const branchConst = (schema, discriminator) => schema?.properties?.[discriminator]?.const
+
+/**
+ * @param {Record<string, any>} schemasById all schemas known to the ajv instance, keyed by $id
+ * @param {any} rootSchema the schema currently being walked (for local `#/...` refs)
+ * @param {string} ref
+ * @returns {any}
+ */
+const resolveRef = (schemasById, rootSchema, ref) => {
+  const [id, fragment] = ref.split('#')
+  let node = id ? schemasById[id] : rootSchema
+  for (const part of (fragment ?? '').split('/').filter(Boolean)) {
+    node = node?.[part.replace(/~1/g, '/').replace(/~0/g, '~')]
+  }
+  return node
+}
+
+/**
+ * Rewrite every discriminated `oneOf` reachable from `rootSchema` into an
+ * equivalent, faster `allOf` of `if/then` guards. Mutates in place.
+ * @param {any} rootSchema
+ * @param {Record<string, any>} schemasById
+ */
+export const rewriteDiscriminatedOneOfs = (rootSchema, schemasById) => {
+  const seen = new Set()
+  /** @param {any} node */
+  const walk = (node) => {
+    if (!node || typeof node !== 'object' || seen.has(node)) return
+    seen.add(node)
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item)
+      return
+    }
+    const discriminator = node.discriminator?.propertyName
+    if (typeof discriminator === 'string' && Array.isArray(node.oneOf)) {
+      const tagOnlyBranches = []
+      const guards = []
+      let fastPath = true
+      for (const branch of node.oneOf) {
+        // Only branches that are a plain `$ref` are eligible: an inline branch is
+        // addressable by its own `#/.../oneOf/N` pointer (json-layout compiles a
+        // validator for it), which we must not disturb. `$ref` branches are
+        // addressed through their ref target, so the reshaped `oneOf` below is safe.
+        const constValue = branch?.$ref ? branchConst(resolveRef(schemasById, rootSchema, branch.$ref), discriminator) : undefined
+        if (constValue === undefined) { fastPath = false; break } // keep the oneOf untouched
+        const guard = { required: [discriminator], properties: { [discriminator]: { const: constValue } } }
+        tagOnlyBranches.push(guard)
+        guards.push({ if: guard, then: branch })
+      }
+      if (fastPath) {
+        node.oneOf = tagOnlyBranches
+        node.allOf = (node.allOf ?? []).concat(guards)
+        // ajv's `discriminator` keyword is incompatible with `unevaluatedProperties`;
+        // the tag-only `oneOf` is cheap enough to resolve sequentially.
+        delete node.discriminator
+      }
+    }
+    for (const key of Object.keys(node)) {
+      if (key === 'discriminator') continue
+      walk(node[key])
+    }
+  }
+  walk(rootSchema)
+}

--- a/core/test/discriminated-oneof.spec.js
+++ b/core/test/discriminated-oneof.spec.js
@@ -1,0 +1,167 @@
+import { describe, it } from 'node:test'
+import { strict as assert } from 'node:assert'
+import { compile, StatefulLayout } from '../src/index.js'
+import ajvModule from 'ajv/dist/2019.js'
+import addFormats from 'ajv-formats'
+import ajvErrors from 'ajv-errors'
+
+// @ts-ignore
+const Ajv = /** @type {typeof ajvModule.default} */ (ajvModule)
+
+const makeAjv = () => {
+  const ajv = new Ajv({ allErrors: true, strict: false, verbose: true })
+  addFormats.default(ajv)
+  ajvErrors.default(ajv)
+  return ajv
+}
+
+describe('Fast-path rewrite of discriminated oneOfs', () => {
+  const defaultOptions = { debounceInputMs: 0 }
+
+  /** @returns {any} */
+  const makeElementSchema = () => ({
+    type: 'object',
+    unevaluatedProperties: false,
+    discriminator: { propertyName: 'key' },
+    oneOf: [{ $ref: '#/$defs/oneOf1' }, { $ref: '#/$defs/oneOf2' }],
+    $defs: {
+      oneOf1: {
+        required: ['key', 'str1'],
+        properties: {
+          key: { type: 'string', const: 'key1' },
+          str1: { type: 'string' }
+        }
+      },
+      oneOf2: {
+        required: ['key', 'str2'],
+        properties: {
+          key: { type: 'string', const: 'key2' },
+          str2: { type: 'string' }
+        }
+      }
+    }
+  })
+
+  it('should rewrite an eligible oneOf and preserve validation behavior', async () => {
+    const compiledLayout = await compile(makeElementSchema())
+    // the oneOf was replaced by cheap tag-only branches and the deep validation moved to if/then guards
+    assert.equal(compiledLayout.schema?.allOf?.length, 2)
+    assert.ok(compiledLayout.schema?.allOf?.[0].then.$ref)
+    assert.ok(!compiledLayout.schema?.oneOf?.[0].$ref)
+
+    const statefulLayout = new StatefulLayout(compiledLayout, compiledLayout.skeletonTrees[compiledLayout.mainTree], defaultOptions, { key: 'key1', str1: 'ok' })
+    assert.equal(statefulLayout.valid, true)
+    statefulLayout.data = { key: 'key1' }
+    assert.equal(statefulLayout.valid, false)
+    const statefulLayout2 = new StatefulLayout(compiledLayout, compiledLayout.skeletonTrees[compiledLayout.mainTree], defaultOptions, {})
+    assert.equal(statefulLayout2.valid, false)
+    assert.equal(statefulLayout2.stateTree.root.children?.find(c => c.key === '$oneOf')?.error, 'chose one')
+  })
+
+  it('should not mutate the schemas registered on a user-supplied ajv instance', async () => {
+    const ajv = makeAjv()
+    const { $defs, ...element } = makeElementSchema()
+    const elementsSchema = {
+      $id: 'https://test.com/elements',
+      $defs: { element, ...$defs }
+    }
+    ajv.addSchema(elementsSchema)
+    const compiledLayout = await compile({
+      type: 'object',
+      properties: {
+        element: { $ref: 'https://test.com/elements#/$defs/element' }
+      }
+    }, { ajv })
+
+    // the caller's schema object is left untouched
+    assert.ok(elementsSchema.$defs.element.discriminator)
+    assert.ok(elementsSchema.$defs.element.oneOf[0].$ref)
+    assert.ok(!(/** @type {any} */(elementsSchema.$defs.element).allOf))
+    // but the fast path was applied to the version known to ajv
+    const registered = /** @type {any} */(ajv.getSchema('https://test.com/elements')?.schema)
+    assert.equal(registered?.$defs.element.allOf?.length, 2)
+
+    const statefulLayout = new StatefulLayout(compiledLayout, compiledLayout.skeletonTrees[compiledLayout.mainTree], defaultOptions, { element: { key: 'key1', str1: 'ok' } })
+    assert.equal(statefulLayout.valid, true)
+    statefulLayout.data = { element: { key: 'key1' } }
+    assert.equal(statefulLayout.valid, false)
+  })
+
+  it('should keep applying the rewrite when recompiling with the same ajv instance', async () => {
+    const ajv = makeAjv()
+    const { $defs, ...element } = makeElementSchema()
+    const schema = {
+      type: 'object',
+      properties: {
+        element: { $ref: '#/$defs/element' }
+      },
+      $defs: { element, ...$defs }
+    }
+    const compiledLayout1 = await compile(schema, { ajv })
+    assert.equal(/** @type {any} */(compiledLayout1.schema)?.$defs.element.allOf?.length, 2)
+    const compiledLayout2 = await compile(schema, { ajv })
+    assert.equal(/** @type {any} */(compiledLayout2.schema)?.$defs.element.allOf?.length, 2)
+  })
+
+  it('should leave the oneOf untouched when a branch does not require the discriminator', async () => {
+    const schema = makeElementSchema()
+    schema.$defs.oneOf1.required = ['str1']
+    delete schema.unevaluatedProperties
+    const compiledLayout = await compile(schema)
+    assert.ok(!compiledLayout.schema?.allOf)
+    assert.ok(compiledLayout.schema?.oneOf?.[0].$ref)
+
+    // data without the discriminator that matches exactly one branch is valid, as before the rewrite
+    const statefulLayout = new StatefulLayout(compiledLayout, compiledLayout.skeletonTrees[compiledLayout.mainTree], defaultOptions, { str1: 'ok' })
+    assert.equal(statefulLayout.valid, true)
+  })
+
+  it('should leave the oneOf untouched when two branches share the same discriminator const', async () => {
+    const schema = makeElementSchema()
+    schema.$defs.oneOf2.properties.key.const = 'key1'
+    delete schema.unevaluatedProperties
+    const compiledLayout = await compile(schema)
+    assert.ok(!compiledLayout.schema?.allOf)
+    assert.ok(compiledLayout.schema?.oneOf?.[0].$ref)
+
+    // data that fully matches only the first branch is valid, as before the rewrite
+    const statefulLayout = new StatefulLayout(compiledLayout, compiledLayout.skeletonTrees[compiledLayout.mainTree], defaultOptions, { key: 'key1', str1: 'ok' })
+    assert.equal(statefulLayout.valid, true)
+  })
+
+  it('should not rewrite schema-lookalike values stored in data keywords', async () => {
+    const schema = makeElementSchema()
+    /** @type {any} */
+    const lookalike = {
+      discriminator: { propertyName: 'key' },
+      oneOf: [{ $ref: '#/$defs/oneOf1' }]
+    }
+    schema.$defs.oneOf1.properties.data = { type: 'object', default: structuredClone(lookalike) }
+    const compiledLayout = await compile(schema)
+    assert.deepEqual(/** @type {any} */(compiledLayout.schema)?.$defs.oneOf1.properties.data.default, lookalike)
+  })
+
+  it('should resolve relative refs to other registered schemas', async () => {
+    const ajv = makeAjv()
+    ajv.addSchema({
+      $id: 'https://test.com/branches',
+      $defs: {
+        oneOf1: {
+          required: ['key', 'str1'],
+          properties: {
+            key: { type: 'string', const: 'key1' },
+            str1: { type: 'string' }
+          }
+        }
+      }
+    })
+    const compiledLayout = await compile({
+      $id: 'https://test.com/main',
+      type: 'object',
+      discriminator: { propertyName: 'key' },
+      oneOf: [{ $ref: 'branches#/$defs/oneOf1' }]
+    }, { ajv })
+    assert.equal(compiledLayout.schema?.allOf?.length, 1)
+    assert.ok(compiledLayout.schema?.allOf?.[0].then.$ref)
+  })
+})


### PR DESCRIPTION
A plain `oneOf` validates the data against every branch in full (even more so with `allErrors`), which on a large discriminated union (one branch per element type, nested in a big document) costs seconds on each revalidation. At compile time, discriminated `oneOf`s of `$ref` branches are now rewritten into a cheap tag-only `oneOf` (preserving the "exactly one variant" semantics and the error surfaced on the `$oneOf` node) plus an `allOf` of `if/then` guards keyed on the discriminator, so only the matching branch is validated in full.

Measured on a real-world recursive schema (40 `$ref` branches, `unevaluatedProperties: false`, ~1000 nested elements): full validation + state update cycle 1190ms → 455ms, StatefulLayout init 1340ms → 700ms. In the consuming app the main-thread cost of a keystroke went from tens of seconds to under a second.

**Why not ajv's `discriminator` keyword:** it does not participate in `unevaluatedProperties` evaluation and would wrongly flag every property of the matched branch as unevaluated. `oneOf`/`allOf`/`if`/`then` all contribute annotations, so `unevaluatedProperties` keeps working.

The fast path only applies when every branch is a plain `$ref` whose target exposes a `const` for the discriminator property, requires that property, and no `const` is shared by two branches — otherwise the `oneOf` is left strictly untouched. Inline branches are excluded because they are addressed by their own `#/.../oneOf/N` pointer. Schemas registered on the (possibly caller-supplied) ajv instance are never mutated: a rewritten clone is swapped into the ajv registry instead. The walker does not recurse into data keywords (`const`, `enum`, `default`, `examples`) and branch refs are resolved through the ajv `uriResolver` so relative refs benefit too. Covered by `core/test/discriminated-oneof.spec.js` (rewrite applied, validation equivalence, non-mutation, recompile with a shared ajv, bail-out cases, relative refs).

**Heads-up:** after `compile()`, registered schemas containing an eligible discriminated `oneOf` are replaced in the ajv registry by their rewritten clone (the caller's objects are untouched). CI may go red on `lists-get-items.spec.js` — that flakiness is pre-existing (timing race under concurrent test files), not caused by this change.
